### PR TITLE
Return correct status when module is not loaded

### DIFF
--- a/scripts/start-stop-status
+++ b/scripts/start-stop-status
@@ -11,7 +11,7 @@ case $1 in
 		exit 0
 	;;
 	status)
-		/sbin/lsmod | grep hello_kernel && exit 0 || exit 255
+		/sbin/lsmod | grep hello_kernel && exit 0 || exit 3
 	;;
 	killall)
         ;;


### PR DESCRIPTION
Per developer guide the value 3 should indicate that package is not running. Returning 255 effects package manager (6.1) and it isn't possible to start nor stop the package (only uninstall is possible). 
https://developer.synology.com/developer-guide/synology_package/scripts.html